### PR TITLE
refactor(findUserByEmail): add token in header for find user in micro…

### DIFF
--- a/domain/model/src/main/java/co/com/crediya/requests/model/user/gateways/UserGateway.java
+++ b/domain/model/src/main/java/co/com/crediya/requests/model/user/gateways/UserGateway.java
@@ -4,5 +4,5 @@ import co.com.crediya.requests.model.user.User;
 import reactor.core.publisher.Mono;
 
 public interface UserGateway {
-    Mono<User> findUserByEmail(String email);
+    Mono<User> findUserByEmail(String email, String token);
 }

--- a/domain/usecase/src/main/java/co/com/crediya/requests/usecase/loanApplication/LoanApplicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/crediya/requests/usecase/loanApplication/LoanApplicationUseCase.java
@@ -30,8 +30,8 @@ public class LoanApplicationUseCase {
      * @param request The request to be created.
      * @return A Mono that emits a saved request or an error if the type loan or status is not found.
      */
-    public Mono<LoanApplication> createRequest(LoanApplication request) {
-        return userGateway.findUserByEmail(request.getEmail())
+    public Mono<LoanApplication> createRequest(LoanApplication request, String token) {
+        return userGateway.findUserByEmail(request.getEmail(), token)
                 .switchIfEmpty(Mono.error(new RecordNotFoundException("User with email " + request.getEmail() + " not found in System Crediya")))
                 .flatMap(user -> typeLoanRepository.findByName(request.getTypeLoan().getNames())
                         .switchIfEmpty(Mono.error(new RecordNotFoundException("Type loan " + request.getTypeLoan().getNames() + " not found in database")))

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/crediya/requests/consumer/RestConsumer.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/crediya/requests/consumer/RestConsumer.java
@@ -7,6 +7,7 @@ import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -19,11 +20,12 @@ public class RestConsumer implements UserGateway {
 
     @Override
     @CircuitBreaker(name = "validateEmailUser")
-    public Mono<User> findUserByEmail(String email) {
+    public Mono<User> findUserByEmail(String email, String token) {
         log.info("Finding user by email: {}", email);
         return client
                 .get()
                 .uri("/users/{email}", email)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .retrieve()
                 .bodyToMono(User.class)
                 .switchIfEmpty(Mono.error(new RecordNotFoundException("User not found with email: " + email)))

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/requests/api/Handler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/requests/api/Handler.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Validator;
@@ -21,7 +20,10 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Mono;
 
+import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
@@ -103,6 +105,22 @@ public class Handler {
      */
     public Mono<ServerResponse> createLoanApplication(ServerRequest request){
         log.info("Request received to create loan application");
+
+        String token = request.headers().firstHeader("Authorization");
+
+        if (token == null || token.isEmpty() || !token.startsWith("Bearer ")) {
+            log.error("Authorization header is missing or malformed.");
+
+            Map<String, Object> errorBody = new HashMap<>();
+            errorBody.put("timestamp", new Date());
+            errorBody.put("status", 401);
+            errorBody.put("error", "Unauthorized");
+            errorBody.put("message", "Authorization header is missing or invalid.");
+            return ServerResponse.status(401).bodyValue(errorBody);
+        }
+
+        String rawToken = token.substring(7);
+
         return request.bodyToMono(LoanApplicationRequest.class)
                 .doOnNext(loanApplicationRequest -> {
                     BeanPropertyBindingResult errors = new BeanPropertyBindingResult(loanApplicationRequest, "loanApplicationRequest");
@@ -116,7 +134,7 @@ public class Handler {
                     }
                 })
                 .map(LoanApplicationDataMapper::toLoanApplication)
-                .flatMap(loanApplicationUseCase::createRequest)
+                .flatMap(loanApplication -> loanApplicationUseCase.createRequest(loanApplication, rawToken))
                 .map(LoanApplicationDataMapper::toLoanApplicationResponse)
                 .flatMap(loanApplication -> ServerResponse.ok().bodyValue(loanApplication))
                 .doOnSuccess(serverResponse -> log.info("Loan application created successfully"))

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/requests/api/config/OpenApiConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/requests/api/config/OpenApiConfig.java
@@ -1,0 +1,27 @@
+package co.com.crediya.requests.api.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "CrediYa Loan Application API",
+                version = "1.0",
+                description = "API for loan application management"
+        ),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        description = "JWT token for authentication"
+)
+public class OpenApiConfig {
+}


### PR DESCRIPTION
Changes
- Modified RestConsumer: The findUserByEmail method in RestConsumer now accepts a token as a parameter.
- Authentication Header: The provided token is now included in the Authorization header of the HTTP request to the authentication microservice. This is done by prepending "Bearer " to the token.